### PR TITLE
Fixed issue with sm build and made multi-region

### DIFF
--- a/tutorials/QuestionAnsweringMachine/01_QuestionAnsweringWithT5SSM.ipynb
+++ b/tutorials/QuestionAnsweringMachine/01_QuestionAnsweringWithT5SSM.ipynb
@@ -60,15 +60,16 @@
     "sess = sagemaker.Session()\n",
     "role = sagemaker.get_execution_role()\n",
     "bucket = sess.default_bucket()\n",
+    "region=sess.boto_region_name\n",
     "\n",
-    "image_name=f\"{sess.account_id()}.dkr.ecr.{sess.boto_region_name}.amazonaws.com/pytorch-training-neuron\"\n",
+    "image_name=\"pytorch-training-neuron\"\n",
     "image_tag=\"1.13.1-neuron-py38-sdk2.9.0-ubuntu20.04\"\n",
-    "image_uri=f\"{image_name}:{image_tag}\"\n",
+    "image_uri=f\"{sess.account_id()}.dkr.ecr.{region}.amazonaws.com/{image_name}:{image_tag}\"\n",
     "print(image_uri)\n",
     "\n",
     "print(f\"sagemaker role arn: {role}\")\n",
     "print(f\"sagemaker bucket: {bucket}\")\n",
-    "print(f\"sagemaker session region: {sess.boto_region_name}\")"
+    "print(f\"sagemaker session region: {region}\")"
    ]
   },
   {
@@ -212,7 +213,8 @@
    "outputs": [],
    "source": [
     "%%writefile container/Dockerfile\n",
-    "FROM 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training-neuron:1.13.0-neuron-py38-sdk2.8.0-ubuntu20.04\n",
+    "ARG REGION=us-east-1\n",
+    "FROM 763104351884.dkr.ecr.$REGION.amazonaws.com/pytorch-training-neuron:1.13.0-neuron-py38-sdk2.8.0-ubuntu20.04\n",
     "\n",
     "RUN apt update && apt install -y \\\n",
     "    aws-neuronx-dkms=2.* \\\n",
@@ -232,7 +234,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!sm-docker build container --repository $image_uri"
+    "!sm-docker build container --repository $image_name:$image_tag --compute-type BUILD_GENERAL1_MEDIUM --build-arg REGION=$region"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

SM build doesn't work as full image uri passed in as arg rather than just the image name and tag. Also, was getting out of memory errors and not portable to other regions

*Description of changes:*
- Fixed image name param to sm build script to use simple name and tag
- Changed CodeBuild compute type to medium (from the default small)
- Added Dockerfile param for region so it can work in other regions (e.g. us-west-2)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
