### PR TITLE
Updated the notebooks to work with the new NKI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The content you find here is focused on particular use cases. If you're looking 
 |:-|:-|
 |[Fine-tune and deploy LLM from Hugging Face on AWS Trainium and AWS Inferentia](workshops/01_FineTuneSpamClassifier)|Learn how to create a spam classifier that can be easily integrated to your own application|
 |[Adapting LLMs for domain-aware applications with AWS Trainium post-training](workshops/02_DomainAdaptation)|Learn how to adapt a pre-trained model to your own business needs and add a conversational interface your customers can interact with|
-|[Adapting LLMs for domain-aware applications with AWS Trainium post-training](workshops/03_NKIWorkshop)|Learn how to use the Neuron Kernel Interface (NKI) to write kernels for Neuron accelerators|
+|[Building Custom Accelerator Kernels with AWS Neuron Kernel Interface (NKI)](workshops/03_NKIWorkshop)|Learn how to use the Neuron Kernel Interface (NKI) to write kernels for Neuron accelerators|
 
 
 These workshops are supported by **AWS Workshop Studio**

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The content you find here is focused on particular use cases. If you're looking 
 |:-|:-|
 |[Fine-tune and deploy LLM from Hugging Face on AWS Trainium and AWS Inferentia](workshops/01_FineTuneSpamClassifier)|Learn how to create a spam classifier that can be easily integrated to your own application|
 |[Adapting LLMs for domain-aware applications with AWS Trainium post-training](workshops/02_DomainAdaptation)|Learn how to adapt a pre-trained model to your own business needs and add a conversational interface your customers can interact with|
+|[Adapting LLMs for domain-aware applications with AWS Trainium post-training](workshops/03_NKIWorkshop)|Learn how to use the Neuron Kernel Interface (NKI) to write kernels for Neuron accelerators|
+
 
 These workshops are supported by **AWS Workshop Studio**
 

--- a/workshops/03_NKIWorkshop/README.md
+++ b/workshops/03_NKIWorkshop/README.md
@@ -15,7 +15,7 @@ NKI follows a three-phase programming model that gives developers explicit contr
 
 1. Load - Move data from device memory (HBM) to on-chip memory (SBUF)
    * Explicitly define which data to bring into fast on-chip memory
-   * Control memory access patterns to optimize bandwidth utilization\
+   * Control memory access patterns to optimize bandwidth utilization
    * Apply data transformations during loading if needed
 
 2. Compute - Perform operations using on-chip memory

--- a/workshops/03_NKIWorkshop/notebooks/0-setup.ipynb
+++ b/workshops/03_NKIWorkshop/notebooks/0-setup.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,19 +65,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "from neuronxcc import nki\n",
     "import neuronxcc.nki.language as nl\n",
     "\n",
-    "def nki_tensor_add_kernel(a_input, b_input, c_output):\n",
+    "@nki.jit\n",
+    "def nki_tensor_add_kernel(a_input, b_input):\n",
     "    \"\"\"\n",
     "    NKI kernel to compute element-wise addition of two input tensors\n",
     "    \"\"\"\n",
-    "\n",
+    "    \n",
     "    # Check all input/output tensor shapes are the same for element-wise operation\n",
-    "    assert a_input.shape == b_input.shape == c_output.shape\n",
+    "    assert a_input.shape == b_input.shape\n",
     "\n",
     "    # Check size of the first dimension does not exceed on-chip memory tile size limit,\n",
     "    # so that we don't need to tile the input to keep this example simple\n",
@@ -90,98 +92,109 @@
     "    # Specify the computation (in our case: a + b)\n",
     "    c_tile = nl.add(a_tile, b_tile)\n",
     "\n",
+    "    # Create a HBM tensor as the kernel output\n",
+    "    c_output = nl.ndarray(a_input.shape, dtype=a_input.dtype, buffer=nl.shared_hbm)\n",
+    "\n",
     "    # Store the result to c_output from on-chip memory to device memory\n",
-    "    nl.store(c_output, value=c_tile)"
+    "    nl.store(c_output, value=c_tile)\n",
+    "\n",
+    "    # Return kernel output as function output\n",
+    "    return c_output"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## NKI baremetal\n",
+    "## Running the kernel\n",
+    "Next, we will cover unique ways to run the above NKI kernel on a NeuronDevice:\n",
     "\n",
-    "To run the above `nki_tensor_add_kernel` kernel in baremetal mode, we can decorate the function with `@baremetal` as follows:\n",
+    "1. NKI baremetal: run NKI kernel with no ML framework involvement\n",
+    "2. PyTorch: run NKI kernel as a PyTorch operator\n",
+    "3. JAX: run NKI kernel as a JAX operator (not used in this workshop)\n",
     "\n",
-    "\n",
-    "```python\n",
-    "@baremetal\n",
-    "def nki_tensor_add_kernel(a_input, b_input, c_output):\n",
+    "All three run modes can call the same kernel function decorated with the `nki.jit` decorator as discussed above:\n",
     "```\n",
+    "@nki.jit\n",
+    "def nki_tensor_add_kernel(a_input, b_input):\n",
+    "```\n",
+    "The `nki.jit` decorator automatically chooses the correct run mode by checking the incoming tensor type:\n",
     "\n",
-    "See [nki.baremetal](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/api/generated/nki.baremetal.html) API doc for available input arguments to the decorator. `nki.baremetal` expects input and output tensors of the NKI kernel to be NumPy arrays. To invoke the kernel, we first initialize the two input tensors `a` and `b` and the output tensor `c` as NumPy arrays. In this scenario, it’s not necessary to zero out the output tensor, as it will be completely overwritten by the result of the addition. However, in some cases, a kernel might overwrite only a part of the output tensor, and the user might want to reset it beforehand to avoid garbage data. Finally, we call the NKI kernel just like any other Python function"
+    "1. NumPy arrays as input: run in NKI baremetal mode\n",
+    "2. PyTorch tensors as input: run in PyTorch mode\n",
+    "3. JAX tensors: run in JAX mode\n",
+    "\n",
+    "See [nki.jit](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/api/generated/nki.jit.html) API doc for more details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### NKI baremetal\n",
+    "\n",
+    "Baremetal mode expects input tensors of the NKI kernel to be NumPy arrays. The kernel also converts its NKI output tensors to NumPy arrays. To invoke the kernel, we first initialize the two input tensors `a` and `b` as NumPy arrays. Finally, we call the NKI kernel just like any other Python function:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from neuronxcc.nki import baremetal\n",
-    "\n",
-    "\"\"\"\n",
-    "Note that this is the same as: \n",
-    "\n",
-    "@baremetal\n",
-    "def nki_tensor_add_kernel(a_input, b_input, c_output):\n",
-    "\"\"\"\n",
-    "nki_tensor_add_kernel_baremetal = baremetal(nki_tensor_add_kernel) \n",
-    "\n",
     "import numpy as np\n",
     "\n",
     "a = np.ones((4, 3), dtype=np.float16)\n",
     "b = np.ones((4, 3), dtype=np.float16)\n",
-    "c = np.zeros((4, 3), dtype=np.float16)\n",
     "\n",
     "# Run NKI kernel on a NeuronDevice\n",
-    "nki_tensor_add_kernel_baremetal(a, b, c)\n",
+    "c = nki_tensor_add_kernel(a, b)\n",
     "\n",
-    "print(c)\n"
+    "print(c)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## PyTorch\n",
+    "> Alternatively, we can decorate the kernel with [nki.baremetal](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/api/generated/nki.baremetal.html) or pass the `mode` parameter to the `nki.jit` decorator, `@nki.jit(mode='baremetal')`, to bypass the dynamic mode detection. See [nki.baremetal](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/api/generated/nki.baremetal.html) API doc for more available input arguments for the baremetal mode."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### PyTorch\n",
     "\n",
-    "To run the above `nki_tensor_add_kernel` kernel using PyTorch, we can decorate the function with `@nki_jit` as follows:\n",
-    "\n",
-    "```python\n",
-    "@nki_jit\n",
-    "def nki_tensor_add_kernel(a_input, b_input, c_output):\n",
-    "```\n",
-    "\n",
-    "The kernel caller code is highly similar to NKI baremetal mode, except the input and output tensors must now be initialized as PyTorch `device` tensors instead."
+    "To run the above `nki_tensor_add_kernel` kernel using PyTorch, we initialize the input and output tensors as PyTorch `device` tensors instead."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import torch\n",
     "from torch_xla.core import xla_model as xm\n",
-    "from torch_neuronx import nki_jit\n",
     "\n",
-    "\"\"\"\n",
-    "Note that this is the same as: \n",
-    "\n",
-    "@nki_jit\n",
-    "def nki_tensor_add_kernel(a_input, b_input, c_output):\n",
-    "\"\"\"\n",
-    "nki_tensor_add_kernel_pytorch = nki_jit(nki_tensor_add_kernel)\n",
+    "nki_tensor_add_kernel_pytorch = nki.jit(nki_tensor_add_kernel, mode='torchxla')\n",
     "\n",
     "device = xm.xla_device()\n",
     "\n",
     "a = torch.ones((4, 3), dtype=torch.float16).to(device=device)\n",
     "b = torch.ones((4, 3), dtype=torch.float16).to(device=device)\n",
-    "c = torch.zeros((4, 3), dtype=torch.float16).to(device=device)\n",
     "\n",
-    "nki_tensor_add_kernel_pytorch(a, b, c)\n",
+    "c = nki_tensor_add_kernel_pytorch(a, b)\n",
     "\n",
-    "print(c) # an implicit XLA barrier/mark-step (triggers XLA compilation)"
+    "print(c)  # an implicit XLA barrier/mark-step (triggers XLA compilation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Alternatively, we can pass the `mode='torchxla'` parameter into the `nki.jit` decorator to bypass the dynamic mode detection."
    ]
   },
   {
@@ -202,6 +215,13 @@
     "import IPython\n",
     "IPython.Application.instance().kernel.do_shutdown(True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -209,8 +229,20 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/workshops/03_NKIWorkshop/notebooks/1-intergrate-prebuild-kernel.ipynb
+++ b/workshops/03_NKIWorkshop/notebooks/1-intergrate-prebuild-kernel.ipynb
@@ -26,15 +26,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "ac49767c",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from neuronxcc import nki\n",
     "from neuronxcc.nki.kernels import flash_fwd as FlashAttentionForward\n",
-    "from torch_neuronx.xla_impl.ops import nki_jit\n",
     "\n",
-    "_flash_fwd_call = nki_jit()(FlashAttentionForward)"
+    "_flash_fwd_call = nki.jit()(FlashAttentionForward)"
    ]
   },
   {
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "c4b3f3da",
    "metadata": {},
    "outputs": [],
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "b5ddff7c",
    "metadata": {},
    "outputs": [],
@@ -225,17 +225,13 @@
     "        k = k.permute(0, 1, 3, 2)\n",
     "        v = v.permute(0, 1, 3, 2)\n",
     "\n",
-    "        attn_output = torch.zeros(\n",
-    "            bsz, num_heads, tgt_len, head_dim, dtype=q.dtype, device=q.device\n",
-    "        )\n",
-    "\n",
     "        config = FlashConfig(\n",
     "            **{\"seq_tile_size\": 2048, \"training\": False, \"should_transpose_v\": True}\n",
     "        )\n",
-    "        _flash_fwd_call[bsz, self.mha.num_heads](\n",
-    "            q, k, v, None, attn_output, config=config, use_causal_mask=False\n",
+    "        attn_output = _flash_fwd_call[bsz, self.mha.num_heads](\n",
+    "            q, k, v, seed=None, logit_bias=None, use_causal_mask=False, config=config,\n",
     "        )\n",
-    "\n",
+    "        \n",
     "        attn_output = attn_output.reshape(bsz, num_heads, tgt_len, head_dim)\n",
     "\n",
     "        # *************************************************************************************************\n",
@@ -267,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "308a16dc",
    "metadata": {},
    "outputs": [],
@@ -323,7 +319,7 @@
     "    mha_module_nki,\n",
     "    example_inputs,\n",
     "    compiler_workdir=os.path.join(COMPILER_WORKDIR_ROOT, \"MHA\"),\n",
-    "    compiler_args=\"--model-type=transformer --auto-cast=all --auto-cast-type=bf16 --optlevel=1\",\n",
+    "    compiler_args=[\"--model-type\", \"transformer\", \"--auto-cast\", \"all\", \"--auto-cast-type\", \"bf16\", \"--optlevel\", \"1\"],\n",
     ")"
    ]
   },
@@ -390,6 +386,14 @@
     "import IPython\n",
     "IPython.Application.instance().kernel.do_shutdown(True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cf849ce-2f7b-460a-a9e7-1f9841462613",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/workshops/03_NKIWorkshop/notebooks/2-custom-operators.ipynb
+++ b/workshops/03_NKIWorkshop/notebooks/2-custom-operators.ipynb
@@ -12,36 +12,43 @@
     "\n",
     "Let’s examine a guiding example below where we randomly initialize two inputs, add them together, and then multiply the result by the two input tensors element-wise. This effectively calculates: `a * b * (a + b)`.\n",
     "\n",
-    "We define a common NKI kernel for addition. For more information on the kernel, see [Tensor Addition](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/tutorials/tensor_addition.html)."
+    "We define a common NKI kernel for addition. For more information on the kernel, see [SPMD Tensor Addition](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/tutorials/spmd_tensor_addition.html)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import neuronxcc.nki as nki\n",
     "import neuronxcc.nki.language as nl\n",
     "\n",
-    "\n",
-    "def nki_tensor_add_kernel_(a_input, b_input, c_output):\n",
+    "@nki.jit\n",
+    "def nki_tensor_add_kernel_(a_input, b_input):\n",
     "  \"\"\"NKI kernel to compute element-wise addition of two input tensors\n",
-    "\n",
-    "  This kernel assumes strict input/output tile-sizes, of up-to [128,512]\n",
+    "  \n",
+    "  This kernel assumes strict input/output sizes can be uniformly tiled to [128,512]\n",
     "\n",
     "  Args:\n",
-    "      a_input: a first input tensor, of shape [128,512]\n",
-    "      b_input: a second input tensor, of shape [128,512]\n",
-    "      c_output: an output tensor, of shape [128,512]\n",
+    "      a_input: a first input tensor\n",
+    "      b_input: a second input tensor\n",
+    "\n",
+    "  Returns:\n",
+    "      c_output: an output tensor\n",
     "  \"\"\"\n",
+    "\n",
+    "  # Create output tensor shared between all SPMD instances as result tensor\n",
+    "  c_output = nl.ndarray(a_input.shape, dtype=a_input.dtype, buffer=nl.shared_hbm)\n",
     "\n",
     "  # Calculate tile offsets based on current 'program'\n",
     "  offset_i_x = nl.program_id(0) * 128\n",
     "  offset_i_y = nl.program_id(1) * 512\n",
     "\n",
     "  # Generate tensor indices to index tensors a and b\n",
-    "  ix = offset_i_x + nl.arange(128)[:, None]\n",
-    "  iy = offset_i_y + nl.arange(512)[None, :]\n",
+    "  ix_, iy_ = nl.mgrid[0:128, 0:512]\n",
+    "  ix = offset_i_x + ix_\n",
+    "  iy = offset_i_y + iy_\n",
     "\n",
     "  # Load input data from device memory (HBM) to on-chip memory (SBUF)\n",
     "  # We refer to an indexed portion of a tensor as an intermediate tensor\n",
@@ -52,7 +59,10 @@
     "  c_tile = a_tile + b_tile\n",
     "\n",
     "  # store the addition results back to device memory (c_output)\n",
-    "  nl.store(c_output[ix, iy], value=c_tile)"
+    "  nl.store(c_output[ix, iy], value=c_tile)\n",
+    "\n",
+    "  # Transfer the ownership of `c_output` to the caller\n",
+    "  return c_output"
    ]
   },
   {
@@ -86,7 +96,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let’s replace the tensor addition (`c = a + b`) with a NKI kernel. To do this we replace the `+` operator with a call to the NKI kernel caller (`nki_tensor_add_pytorch`), and everything else works as before. We wrap the addition kernel (`nki_tensor_add_kernel_`) by using the `nki_jit` decorator."
+    "Now let’s replace the tensor addition (`c = a + b`) with a NKI kernel. To do this we replace the `+` operator with a call to the NKI kernel caller (`nki_tensor_add`), and everything else works as before."
    ]
   },
   {
@@ -95,22 +105,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import torch\n",
-    "import torch_xla.core.xla_model as xm\n",
-    "import neuronxcc.nki.language as nl\n",
-    "from torch_neuronx import nki_jit\n",
-    "\n",
-    "nki_tensor_add_kernel_ = nki_jit(nki_tensor_add_kernel_)\n",
-    "\n",
-    "def nki_tensor_add_pytorch(a_input, b_input):\n",
+    "def nki_tensor_add(a_input, b_input):\n",
     "  \"\"\"NKI kernel caller to compute element-wise addition of two input tensors\n",
     "\n",
-    "  This kernel caller lifts tile-size restriction, by applying the kernel on tiles\n",
-    "  of the inputs/outputs\n",
+    "  This kernel caller lifts tile-size restriction, by applying the kernel on tiles of the inputs/outputs\n",
     "\n",
     "  Args:\n",
-    "      a_input:  a first input tensor, of shape [N*128, M*512]\n",
-    "      b_input:  a second input tensor, of shape [N*128, M*512]\n",
+    "      a_input: a first input tensor, of shape [N*128, M*512]\n",
+    "      b_input: a second input tensor, of shape [N*128, M*512]\n",
     "\n",
     "  Returns:\n",
     "      a tensor of shape [N*128, M*512], the result of a_input + b_input\n",
@@ -120,16 +122,13 @@
     "  # In this case, we use a 2D grid where the size of each invocation is 128x512\n",
     "  grid_x = a_input.shape[0] // 128\n",
     "  grid_y = a_input.shape[1] // 512\n",
-    "  c_output = torch.zeros(a_input.shape, dtype=a_input.dtype).to(device=device)\n",
     "\n",
-    "  nki_tensor_add_kernel_[grid_x, grid_y](a_input, b_input, c_output)\n",
-    "\n",
-    "  return c_output\n",
+    "  return nki_tensor_add_kernel_[grid_x, grid_y](a_input, b_input)\n",
     "\n",
     "device = xm.xla_device()\n",
     "a = torch.randn(256, 1024, dtype=torch.float32).to(device)\n",
     "b = torch.randn(256, 1024, dtype=torch.float32).to(device)\n",
-    "c = nki_tensor_add_pytorch(a, b) # calling a NKI kernel, instead of the built-in torch op\n",
+    "c = nki_tensor_add(a, b) # calling a NKI kernel, instead of the built-in torch op\n",
     "out = a * b * c\n",
     "print(out)"
    ]
@@ -143,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,11 +180,11 @@
     "\n",
     "If you are using NKI to implement a new operator in a training graph, you might need to make the new operator interplay with the `autograd` engine in the framework. To do this, in PyTorch, you can subclass the framework’s base operator class and implement both the `forward()` and `backward()` methods. The `autograd` engine then uses the `backward()` method when performing auto-differentiation. See Extending [torch.autograd](https://pytorch.org/docs/stable/notes/extending.html) in the PyTorch Docs for instructions on doing this in PyTorch.\n",
     "\n",
-    "Let’s reuse the `nki_tensor_add_pytorch` kernel from before and demonstrate how to train a simple compute graph `(a+b)*a*b` in PyTorch.\n",
+    "Let’s reuse the `nki_tensor_add` kernel from before and demonstrate how to train a simple compute graph `(a+b)*a*b` in PyTorch.\n",
     "\n",
     "## PyTorch\n",
     "\n",
-    "We define a `NkiAddFunc` class, which leverages the `nki_tensor_add_pytorch` kernel in its `forward()` function. The gradients of both input tensors in `y = a + b` are ones, so the `backward()` function propagates the `dy` gradients from the previous backward function."
+    "We define a `NkiAddFunc` class, which leverages the `nki_tensor_add` kernel in its `forward()` function. The gradients of both input tensors in `y = a + b` are ones, so the `backward()` function propagates the `dy` gradients from the previous backward function."
    ]
   },
   {
@@ -201,7 +200,7 @@
     "class NkiAddFunc(torch.autograd.Function):\n",
     "  @staticmethod\n",
     "  def forward(ctx, a, b):\n",
-    "    return nki_tensor_add_pytorch(a, b)\n",
+    "    return nki_tensor_add(a, b)\n",
     "\n",
     "  @staticmethod\n",
     "  def backward(ctx, dy, *args):\n",
@@ -241,6 +240,13 @@
     "import IPython\n",
     "IPython.Application.instance().kernel.do_shutdown(True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -263,5 +269,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/workshops/03_NKIWorkshop/notebooks/3-neuron-profile.ipynb
+++ b/workshops/03_NKIWorkshop/notebooks/3-neuron-profile.ipynb
@@ -38,21 +38,25 @@
     "Example kernel used to demmonstrate Neuron Profile.\n",
     "\"\"\"\n",
     "import torch\n",
+    "from neuronxcc import nki\n",
     "import neuronxcc.nki.language as nl\n",
-    "from torch_neuronx import nki_jit\n",
     "import math\n",
     "import os\n",
     "os.environ[\"NEURON_FRAMEWORK_DEBUG\"] = \"1\"\n",
     "os.environ[\"NEURON_CC_FLAGS\"]= \" --disable-dge \"\n",
     "\n",
-    "@nki_jit\n",
-    "def tensor_exp_kernel_(in_tensor, out_tensor):\n",
+    "@nki.jit\n",
+    "def tensor_exp_kernel_(in_tensor):\n",
     "  \"\"\"NKI kernel to compute elementwise exponential of an input tensor\n",
     "\n",
     "  Args:\n",
     "      in_tensor: an input tensor of ANY 2D shape (up to SBUF size)\n",
+    "  Returns:\n",
     "      out_tensor: an output tensor of ANY 2D shape (up to SBUF size)\n",
     "  \"\"\"\n",
+    "  out_tensor = nl.ndarray(in_tensor.shape, dtype=in_tensor.dtype,\n",
+    "                          buffer=nl.shared_hbm)\n",
+    "\n",
     "  sz_p, sz_f = in_tensor.shape\n",
     "\n",
     "  i_f = nl.arange(sz_f)[None, :]\n",
@@ -73,14 +77,15 @@
     "    # only write up to sz_p\n",
     "    nl.store(out_tensor[i_p, i_f], value=out_tile, mask=(i_p<sz_p))\n",
     "\n",
+    "    return out_tensor\n",
+    "\n",
     "if __name__ == \"__main__\":\n",
     "  from torch_xla.core import xla_model as xm\n",
     "  device = xm.xla_device()\n",
     "\n",
     "  in_tensor = torch.rand((250, 512), dtype=torch.float32).to(device=device)\n",
-    "  out_tensor = torch.zeros((250, 512), dtype=torch.float32).to(device=device)\n",
     "\n",
-    "  tensor_exp_kernel_(in_tensor, out_tensor)\n",
+    "  out_tensor = tensor_exp_kernel_(in_tensor)\n",
     "  print(f\"output_nki={out_tensor}\")"
    ]
   },
@@ -95,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,18 +178,23 @@
     "\"\"\"\n",
     "Example kernel used to demmonstrate Neuron Profile with nki.benchmark.\n",
     "\"\"\"\n",
-    "from neuronxcc.nki import benchmark\n",
+    "from neuronxcc import nki\n",
     "from neuronxcc.nki.typing import tensor\n",
     "import neuronxcc.nki.language as nl\n",
     "import math\n",
     "\n",
-    "@benchmark(save_neff_name='file.neff', save_trace_name='profile.ntff')\n",
-    "def tensor_exp_kernel_(in_tensor, out_tensor):\n",
+    "\n",
+    "@nki.benchmark(save_neff_name='file.neff', save_trace_name='profile.ntff')\n",
+    "def tensor_exp_kernel_(in_tensor):\n",
     "  \"\"\"NKI kernel to compute elementwise exponential of an input tensor\n",
     "  Args:\n",
     "      in_tensor: an input tensor of ANY 2D shape (up to SBUF size)\n",
+    "  Returns:\n",
     "      out_tensor: an output tensor of ANY 2D shape (up to SBUF size)\n",
     "  \"\"\"\n",
+    "  out_tensor = nl.ndarray(in_tensor.shape, dtype=in_tensor.dtype,\n",
+    "                          buffer=nl.shared_hbm)\n",
+    "\n",
     "  sz_p, sz_f = in_tensor.shape\n",
     "  i_f = nl.arange(sz_f)[None, :]\n",
     "  for p in nl.affine_range(math.ceil(sz_p / nl.tile_size.pmax)):\n",
@@ -200,9 +210,10 @@
     "    # only write up to sz_p\n",
     "    nl.store(out_tensor[i_p, i_f], value=out_tile, mask=(i_p<sz_p))\n",
     "\n",
+    "  return out_tensor\n",
+    "\n",
     "if __name__ == \"__main__\":\n",
-    "  tensor_exp_kernel_(tensor[[250, 512], nl.float32],\n",
-    "                     tensor[[250, 512], nl.float32])"
+    "  tensor_exp_kernel_(tensor[[250, 512], nl.float32])"
    ]
   },
   {
@@ -239,6 +250,13 @@
     "import IPython\n",
     "IPython.Application.instance().kernel.do_shutdown(True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -261,5 +279,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
NKI has changed the programming model from having the output as part of the input (i.e., nki_tensor_add_kernel(a_input, b_input, c_output)) to a more sensible return value based approach (i.e., nki_tensor_add_kernel(a_input, b_input)). They also removed the `@jax`, `@baremetal` and `@nki_jit` decorators in favor of a single `@nki.jit` decorator with different modes

You used to be able to run something like:
```
@baremetal
def nki_tensor_add_kernel(a_input, b_input, c_output):
    """
    NKI kernel to compute element-wise addition of two input tensors
    """

    # Check all input/output tensor shapes are the same for element-wise operation
    assert a_input.shape == b_input.shape == c_output.shape

    # Check size of the first dimension does not exceed on-chip memory tile size limit,
    # so that we don't need to tile the input to keep this example simple
    assert a_input.shape[0] <= nl.tile_size.pmax

    # Load the inputs from device memory to on-chip memory
    a_tile = nl.load(a_input)
    b_tile = nl.load(b_input)

    # Specify the computation (in our case: a + b)
    c_tile = nl.add(a_tile, b_tile)

    # Store the result to c_output from on-chip memory to device memory
    nl.store(c_output, value=c_tile)
```

which is now
```
@nki.jit
def nki_tensor_add_kernel(a_input, b_input):
    """
    NKI kernel to compute element-wise addition of two input tensors

    """
    
    # Check all input/output tensor shapes are the same for element-wise operation
    assert a_input.shape == b_input.shape

    # Check size of the first dimension does not exceed on-chip memory tile size limit,
    # so that we don't need to tile the input to keep this example simple
    assert a_input.shape[0] <= nl.tile_size.pmax

    # Load the inputs from device memory to on-chip memory
    a_tile = nl.load(a_input)
    b_tile = nl.load(b_input)

    # Specify the computation (in our case: a + b)
    c_tile = nl.add(a_tile, b_tile)

    # Create a HBM tensor as the kernel output
    c_output = nl.ndarray(a_input.shape, dtype=a_input.dtype, buffer=nl.shared_hbm)

    # Store the result to c_output from on-chip memory to device memory
    nl.store(c_output, value=c_tile)

    # Return kernel output as function output
    return c_output
```

I've updated the notebooks to work with this new NKI version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
