### PR TITLE
Added disclaimer to warn about the crash in the last cell

### DIFF
--- a/workshops/03_NKIWorkshop/notebooks/0-setup.ipynb
+++ b/workshops/03_NKIWorkshop/notebooks/0-setup.ipynb
@@ -203,7 +203,9 @@
    "source": [
     "## Release the NeuronCore for the next notebook\n",
     "\n",
-    "Before moving to the next notebook we need to release the NeuronCore. If we don't do this the next notebook will not be able resources - you can also stop the kernel via the GUI"
+    "Before moving to the next notebook we need to release the NeuronCore. If we don't do this the next notebook will not be able to use the resources - you can also stop the kernel via the GUI.\n",
+    "\n",
+    "> When running the command in the next cell the notebook will give an error - this is to be expected."
    ]
   },
   {

--- a/workshops/03_NKIWorkshop/notebooks/1-intergrate-prebuild-kernel.ipynb
+++ b/workshops/03_NKIWorkshop/notebooks/1-intergrate-prebuild-kernel.ipynb
@@ -373,7 +373,9 @@
    "source": [
     "## Release the NeuronCore for the next notebook\n",
     "\n",
-    "Before moving to the next notebook we need to release the NeuronCore. If we don't do this the next notebook will not be able resources - you can also stop the kernel via the GUI"
+    "Before moving to the next notebook we need to release the NeuronCore. If we don't do this the next notebook will not be able to use the resources - you can also stop the kernel via the GUI.\n",
+    "\n",
+    "> When running the command in the next cell the notebook will give an error - this is to be expected."
    ]
   },
   {

--- a/workshops/03_NKIWorkshop/notebooks/2-custom-operators.ipynb
+++ b/workshops/03_NKIWorkshop/notebooks/2-custom-operators.ipynb
@@ -228,7 +228,9 @@
    "source": [
     "## Release the NeuronCore for the next notebook\n",
     "\n",
-    "Before moving to the next notebook we need to release the NeuronCore. If we don't do this the next notebook will not be able resources - you can also stop the kernel via the GUI"
+    "Before moving to the next notebook we need to release the NeuronCore. If we don't do this the next notebook will not be able to use the resources - you can also stop the kernel via the GUI.\n",
+    "\n",
+    "> When running the command in the next cell the notebook will give an error - this is to be expected."
    ]
   },
   {

--- a/workshops/03_NKIWorkshop/notebooks/3-neuron-profile.ipynb
+++ b/workshops/03_NKIWorkshop/notebooks/3-neuron-profile.ipynb
@@ -238,7 +238,9 @@
    "source": [
     "## Release the NeuronCore for the next notebook\n",
     "\n",
-    "Before moving to the next notebook we need to release the NeuronCore. If we don't do this the next notebook will not be able resources - you can also stop the kernel via the GUI"
+    "Before moving to the next notebook we need to release the NeuronCore. If we don't do this the next notebook will not be able to use the resources - you can also stop the kernel via the GUI.\n",
+    "\n",
+    "> When running the command in the next cell the notebook will give an error - this is to be expected."
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
When running:
```
import IPython
IPython.Application.instance().kernel.do_shutdown(True)
```
The notebook will give an error that the kernel has crashed - this is expected behavior. To communicated this I've added a disclaimer stating:
```
When running the command in the next cell the notebook will give an error - this is to be expected.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
